### PR TITLE
add ip address to txt data

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -1,6 +1,7 @@
 var chalk = require('chalk')
 var browserSync = require('browser-sync')
 var os = require('os')
+var ip = require('ip')
 var fs = require('fs')
 var path = require('path')
 var logClient = fs.readFileSync(
@@ -41,13 +42,13 @@ module.exports = function(options) {
 		}
 	}, function(err, bs) {
 		require('./socketLogger')(bs.io.sockets)
-		require('./servicePublisher').publish(os.hostname(), bs.options.get('port'), options.mcode, options.slug)
+		require('./servicePublisher').publish(os.hostname(), bs.options.get('port'), options.mcode, options.slug, ip.address())
 
 		var manifestPath = path.join(process.cwd(), 'interactive-manifest.json')
 		var manifestExists = fs.existsSync(manifestPath)
 
 		if (!manifestExists) {
-			
+
 			return console.log(chalk.red('WARNING: This Extension is missing `interactive-manifest.json` file. Adding this file will allow the Extension to leverage some important enhancements to the apps. Run command "extension-cli init" again to have the file added to the root of your Extension.'))
 		}
 

--- a/lib/servicePublisher.js
+++ b/lib/servicePublisher.js
@@ -2,7 +2,7 @@ var async = require('async-kit')
 var bonjour = require('bonjour')()
 var _ = require('lodash')
 
-function publish(hostname, port, mcode, slug) {
+function publish(hostname, port, mcode, slug, ip) {
 
 	hostname = hostname.replace('.lan', '.local')
 
@@ -13,7 +13,8 @@ function publish(hostname, port, mcode, slug) {
 		port,
 		txt: {
 			mcode,
-			slug
+			slug,
+			ip
 		}
 	})
 }


### PR DESCRIPTION
Adding the address to the txtData. This will help iOS 11 get past ATS around connecting to devices that use the .local domain.

This info is additive so, in theory all other platforms should be unaffected.